### PR TITLE
Fix UI issues with show page

### DIFF
--- a/app/assets/stylesheets/pages/_request_show.scss
+++ b/app/assets/stylesheets/pages/_request_show.scss
@@ -55,6 +55,7 @@
 
 .request-description-field {
   margin-bottom: 60px;
+  width: 75%;
 }
 
 .edit-btn {

--- a/app/assets/stylesheets/pages/_request_show.scss
+++ b/app/assets/stylesheets/pages/_request_show.scss
@@ -112,3 +112,8 @@
 .request-conversation-btn {
   margin-top: 16px;
 }
+
+.request-show-buttons {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/app/assets/stylesheets/pages/_request_show.scss
+++ b/app/assets/stylesheets/pages/_request_show.scss
@@ -54,7 +54,7 @@
 }
 
 .request-description-field {
-  margin-bottom: 60px;
+  margin-bottom: 45px;
   width: 75%;
 }
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -16,7 +16,7 @@ class RequestsController < ApplicationController
     authorize @request
     @conversation_count = @request.conversations.count
     @id = @request.helper_id
-    @id ? @helper = User.find(@id) : @helper = nil
+    #@id ? @helper = User.find(@id) : @helper = nil
     @helper_conversation = Conversation.find_by(request_id: @request.id, helper_id: @request.helper, creator_id: @request.creator_id)
     @conversation = Conversation.new
   end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -16,7 +16,6 @@ class RequestsController < ApplicationController
     authorize @request
     @conversation_count = @request.conversations.count
     @id = @request.helper_id
-    #@id ? @helper = User.find(@id) : @helper = nil
     @helper_conversation = Conversation.find_by(request_id: @request.id, helper_id: @request.helper, creator_id: @request.creator_id)
     @conversation = Conversation.new
   end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -15,8 +15,8 @@ class RequestsController < ApplicationController
     @new_request = Category.find(@request.category_id).name
     authorize @request
     @conversation_count = @request.conversations.count
-    @id = @request.helper_id
     @helper_conversation = Conversation.find_by(request_id: @request.id, helper_id: @request.helper, creator_id: @request.creator_id)
+    @helper_unconfirmed_conversation = Conversation.where(helper_id: current_user.id, request_id: params[:id]).first
     @conversation = Conversation.new
   end
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -17,7 +17,7 @@ class RequestsController < ApplicationController
     @conversation_count = @request.conversations.count
     @id = @request.helper_id
     @id ? @helper = User.find(@id) : @helper = nil
-    @helper_conversation = Conversation.find_by(request_id: @request.id, helper_id: current_user.id, creator_id: @request.creator_id)
+    @helper_conversation = Conversation.find_by(request_id: @request.id, helper_id: @request.helper, creator_id: @request.creator_id)
     @conversation = Conversation.new
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   has_many :requests_as_creator, source: :requests, foreign_key: :creator_id, class_name: "Request"
   has_many :requests_as_helper, source: :requests, foreign_key: :helper_id, class_name: "Request"
   has_many :reviews, through: :requests
- has_many :conversations_as_creator, source: :conversations, foreign_key: :creator_id, class_name: "Conversation"
+  has_many :conversations_as_creator, source: :conversations, foreign_key: :creator_id, class_name: "Conversation"
   has_many :conversations_as_helper, source: :conversations, foreign_key: :helper_id, class_name: "Conversation"
   validates :first_name, :last_name, :location, presence: true
 

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -34,8 +34,10 @@
             <p class="helper-name"><%= @request.helper.first_name %> <%=@request.helper.last_name %></p>
         </div>
         <% end %>
-    <% elsif current_user == @request.helper || current_user.conversations.find { |conv| conv.request == @request }%>
+    <% elsif @helper_unconfirmed_conversation %>
       <%= link_to "Go to conversation", conversation_path(@helper_unconfirmed_conversation), class: "btn btn-outline-secondary request-conversation-btn rounder"%>
+    <% elsif current_user == @request.helper %>
+      <%= link_to "Go to conversation", conversation_path(@helper_conversation), class: "btn btn-outline-secondary request-conversation-btn rounder"%>
     <% elsif @request.status == "pending" && current_user != @request.creator %>
         <%= simple_form_for @conversation do |f| %>
                 <%= f.input :helper_id, input_html: {value: current_user.id}, :as => :hidden%>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -27,7 +27,7 @@
         <h3>Assigned to:</h3>
         <div class="assigned-to-avatar">
           <div class="pending-messages">
-            <%= link_to conversations_path do %>
+            <%= link_to conversation_path(@helper_conversation) do %>
               <%= cl_image_tag @request.helper.photo.key, class: "avatar-large" %>
             <% end %>
           </div>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -34,11 +34,9 @@
             <p class="helper-name"><%= @request.helper.first_name %> <%=@request.helper.last_name %></p>
         </div>
         <% end %>
-    <% elsif %>
-      <% current_user == @request.helper %>
-      <%= link_to "Go to conversation", conversation_path(@helper_conversation), class: "btn btn-outline-secondary request-conversation-btn rounder"%>
-    <% elsif %>
-      <% @request.status == "pending" %>
+    <% elsif current_user == @request.helper || current_user.conversations.find { |conv| conv.request == @request }%>
+      <%= link_to "Go to conversation", conversation_path(@helper_unconfirmed_conversation), class: "btn btn-outline-secondary request-conversation-btn rounder"%>
+    <% elsif @request.status == "pending" && current_user != @request.creator %>
         <%= simple_form_for @conversation do |f| %>
                 <%= f.input :helper_id, input_html: {value: current_user.id}, :as => :hidden%>
                 <%= f.input :creator_id, input_html: {value: @request.creator_id}, :as => :hidden%>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -4,7 +4,6 @@
       <div class="conversation-request-card-status">
         <p id="request-status-show"><%= @request.status.capitalize%></p>
       </div>
-
     </div>
     <div class="request-title-show-wrapper ">
       <p><strong> <%= @request.title %></strong></p>
@@ -22,50 +21,37 @@
     <div class="request-description-field">
       <%= @request.description%>
     </div>
+
     <% if @request.helper.present? && current_user == @request.creator %>
+      <% if @request.helper.photo.attached? %>
         <h3>Assigned to:</h3>
         <div class="assigned-to-avatar">
           <div class="pending-messages">
-            <% if @request.helper.photo.attached? %>
-              <%= link_to conversation_path(@helper_conversation) do %>
-                <%= cl_image_tag @request.helper.photo.key, class: "avatar-large" %>
-              <% end %>
-            <% else %>
-              <%= link_to conversations_path do %>
-                <%= image_tag("waldo.png", class: "avatar-large") %>
-              <% end %>
+            <%= link_to conversations_path do %>
+              <%= cl_image_tag @request.helper.photo.key, class: "avatar-large" %>
             <% end %>
           </div>
             <p class="helper-name"><%= @request.helper.first_name %> <%=@request.helper.last_name %></p>
         </div>
-    <% else %>
-      <% if @request.creator == current_user && @request.status != "inactive" %>
-        <div class="pending-messages">
-          <%= link_to conversations_path do %>
-            <h3>Pending inbox messages: <%= @conversation_count%></h3>
-          <% end %>
-        </div>
-        <div class="request-show-btn">
-          <a href="#" class="btn btn-primary edit-btn rounder">Edit</a>
-          <%= link_to "Cancel", request_path, method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-outline-danger rounder" %>
-        </div>
-      <% else %>
-        <% if @helper_conversation.present? %>
-          <%= link_to "Go to conversation", conversation_path(@helper_conversation), class: "btn btn-outline-secondary request-conversation-btn rounder"%>
-        <% else %>
-          <% if @request.status != "inactive" %>
-            <div class="request-helper-buttons">
-              <%= simple_form_for @conversation do |f| %>
-                <%= f.input :helper_id, input_html: {value: current_user.id}, :as => :hidden%>
-                <%= f.input :creator_id, input_html: {value: @request.creator_id}, :as => :hidden%>
-                <%= f.input :request_id, input_html: {value: @request.id}, :as => :hidden%>
-                <%= f.button :submit, "Start a conversation", class: "btn btn-primary" %>
-              <% end %>
-            </div>
-          <% end %>
         <% end %>
+    <% elsif %>
+      <% current_user == @request.helper %>
+      <%= link_to "Go to conversation", conversation_path(@helper_conversation), class: "btn btn-outline-secondary request-conversation-btn rounder"%>
+    <% else %>
+      <% if @conversation_count.positive? %>
+      <div class="pending-messages">
+        <%= link_to conversations_path do %>
+          <h3>Messages for this request: <%= @conversation_count%></h3>
+        <% end %>
+      </div>
       <% end %>
     <% end %>
+    <div class="request-show-buttons">
+      <% if @request.creator == current_user && @request.status != "inactive" %>
+        <a href="#" class="btn btn-primary edit-btn rounder">Edit</a>
+        <%= link_to "Cancel", request_path, method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-outline-danger rounder" %>
+      <% end %>
+    </div>
   </div>
 </div>
 

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -23,17 +23,21 @@
     </div>
 
     <% if @request.helper.present? && current_user == @request.creator %>
-      <% if @request.helper.photo.attached? %>
-        <h3>Assigned to:</h3>
+        <h3>Your new pal:</h3>
         <div class="assigned-to-avatar">
           <div class="pending-messages">
+            <% if @request.helper.photo.attached? %>
             <%= link_to conversation_path(@helper_conversation) do %>
               <%= cl_image_tag @request.helper.photo.key, class: "avatar-large" %>
+            <% end %>
+            <% else %>
+              <%= link_to conversation_path(@helper_conversation) do %>
+                <%= image_tag("waldo.png", class: "avatar-large") %>
+              <% end %>
             <% end %>
           </div>
             <p class="helper-name"><%= @request.helper.first_name %> <%=@request.helper.last_name %></p>
         </div>
-        <% end %>
     <% elsif @helper_unconfirmed_conversation %>
       <%= link_to "Go to conversation", conversation_path(@helper_unconfirmed_conversation), class: "btn btn-outline-secondary request-conversation-btn rounder"%>
     <% elsif current_user == @request.helper %>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -22,14 +22,13 @@
     <div class="request-description-field">
       <%= @request.description%>
     </div>
-
-    <% if @helper.present? %>
+    <% if @request.helper.present? && current_user != @request.creator %>
         <h3>Assigned to:</h3>
         <div class="assigned-to-avatar">
           <div class="pending-messages">
-            <% if @helper.photo.attached? %>
-              <%= link_to conversations_path do %>
-                <%= cl_image_tag @helper.photo.key, class: "avatar-large" %>
+            <% if @request.helper.photo.attached? %>
+              <%= link_to conversation_path(@helper_conversation) do %>
+                <%= cl_image_tag @request.helper.photo.key, class: "avatar-large" %>
               <% end %>
             <% else %>
               <%= link_to conversations_path do %>
@@ -37,23 +36,19 @@
               <% end %>
             <% end %>
           </div>
-          <%= link_to conversations_path(@helper_conversation) do %>
-            <p class="helper-name"><%= @helper.first_name %> <%=@helper.last_name %></p>
-          <% end %>
+            <p class="helper-name"><%= @request.helper.first_name %> <%=@request.helper.last_name %></p>
         </div>
     <% else %>
-      <% if @request.creator == current_user %>
+      <% if @request.creator == current_user && @request.status != "inactive" %>
         <div class="pending-messages">
           <%= link_to conversations_path do %>
             <h3>Pending inbox messages: <%= @conversation_count%></h3>
           <% end %>
         </div>
-        <% if @request.status != "inactive" %>
-          <div class="request-show-btn">
-            <a href="#" class="btn btn-primary edit-btn rounder">Edit</a>
-            <%= link_to "Cancel", request_path, method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-outline-danger rounder" %>
-          </div>
-        <% end %>
+        <div class="request-show-btn">
+          <a href="#" class="btn btn-primary edit-btn rounder">Edit</a>
+          <%= link_to "Cancel", request_path, method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-outline-danger rounder" %>
+        </div>
       <% else %>
         <% if @helper_conversation.present? %>
           <%= link_to "Go to conversation", conversation_path(@helper_conversation), class: "btn btn-outline-secondary request-conversation-btn rounder"%>
@@ -66,7 +61,6 @@
                 <%= f.input :request_id, input_html: {value: @request.id}, :as => :hidden%>
                 <%= f.button :submit, "Start a conversation", class: "btn btn-primary" %>
               <% end %>
-              <%= link_to "View all open requests", requests_path, class: "btn btn-primary"%>
             </div>
           <% end %>
         <% end %>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -22,7 +22,7 @@
     <div class="request-description-field">
       <%= @request.description%>
     </div>
-    <% if @request.helper.present? && current_user != @request.creator %>
+    <% if @request.helper.present? && current_user == @request.creator %>
         <h3>Assigned to:</h3>
         <div class="assigned-to-avatar">
           <div class="pending-messages">

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -37,6 +37,14 @@
     <% elsif %>
       <% current_user == @request.helper %>
       <%= link_to "Go to conversation", conversation_path(@helper_conversation), class: "btn btn-outline-secondary request-conversation-btn rounder"%>
+    <% elsif %>
+      <% @request.status == "pending" %>
+        <%= simple_form_for @conversation do |f| %>
+                <%= f.input :helper_id, input_html: {value: current_user.id}, :as => :hidden%>
+                <%= f.input :creator_id, input_html: {value: @request.creator_id}, :as => :hidden%>
+                <%= f.input :request_id, input_html: {value: @request.id}, :as => :hidden%>
+                <%= f.button :submit, "Start a conversation", class: "btn btn-primary" %>
+              <% end %>
     <% else %>
       <% if @conversation_count.positive? %>
       <div class="pending-messages">


### PR DESCRIPTION
- Refactored the code and removed some of the request.status inactive logic to get the show view to work again
- Styled buttons to make them rounder
- Hide the messages text when there are no messages
- In a future ticket we'll need to figure out the logic for cancelled help requests on the show page and conversation index